### PR TITLE
ステップ12: Railsのタイムゾーンを設定しよう

### DIFF
--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,4 +1,5 @@
 <li>
   <p class="task_title"><%= link_to task.title, task%></p>
   <p class="task_body"><%= task.body%></p>
+  <p><%= task.created_at%></p>
 </li>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,5 +1,5 @@
 <li>
   <p class="task_title"><%= link_to task.title, task%></p>
   <p class="task_body"><%= task.body%></p>
-  <p><%= task.created_at%></p>
+  <p><%= task.created_at.strftime('%Y/%m/%d %H:%M')%></p>
 </li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,8 @@ module Taskkatta
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :utc 
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-rails%E3%81%AE%E3%82%BF%E3%82%A4%E3%83%A0%E3%82%BE%E3%83%BC%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%82%88%E3%81%86

### 目的
- アプリで扱うタイムゾーンを東京にする

### 達成基準
- railsアプリ上では日時がJSTになっている
- DBにはUTCで保存されてる

### 実装
- application.rbにタイムゾーンの設定を追加
  - DBにはUTCで保存するように
  - アクティブレコード上ではJSTと読み替えるように

### レビューして欲しい点
- 今回はDBの設定をしなくていいようにUTCを採用したましたが、DBはJSTとUCT、どちらにするのが一般的でしょうか？


ローカルDBでUTCで保存されているスクショ
<img width="694" alt="スクリーンショット 2021-04-09 18 09 22" src="https://user-images.githubusercontent.com/37505488/114159076-5eb89f80-9960-11eb-92c7-882f187bbb49.png">


herokuのDBでもUCTで保存されているスクショ
<img width="922" alt="スクリーンショット 2021-04-09 18 08 23" src="https://user-images.githubusercontent.com/37505488/114158982-45afee80-9960-11eb-8d11-e62e4a614f35.png">
