### PR TITLE
[WIP]ステップ13: タスク一覧を作成日時の順番で並び替えよう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :test do
   gem 'faker'
   # gem 'selenium-webdriver'
   # # Easy installation and use of web drivers to run system tests with browsers
-  # gem 'webdrivers'
+  gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (3.0.0)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -209,6 +210,7 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -219,6 +221,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     spring (2.1.1)
     sprockets (4.0.2)
@@ -241,6 +246,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.6.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (5.2.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -278,6 +287,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)
+  webdrivers
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,4 @@
 class Task < ApplicationRecord
   validates :title, presence: true
+  default_scope -> { order(created_at: :desc) }
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    title { 'puipui' }
+    sequence(:title) { |n| "task-#{n}" }
     body { 'pui~' }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'support/factory_bot'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'support/factory_bot'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/tasks_controller_spec.rb
+++ b/spec/requests/tasks_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "TasksControllers", type: :request do
       expect(response.status).to eq 200
     end
     it 'レスポンスにタスクが含まれていること' do
-      expect(response.body).to include "puipui"
+      expect(response.body).to include "pui~"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'capybara/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/driver_setting.rb
+++ b/spec/support/driver_setting.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    # Spec実行時、ブラウザが自動で立ち上がり挙動を確認できる
+    # driven_by(:selenium_chrome)
+
+    # Spec実行時、ブラウザOFF
+    driven_by(:selenium_chrome_headless)
+  end
+end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Task, type: :system do
     it '作成日の降順でタスクがならんでいること' do
       visit tasks_path
       # expect(page.text).to match 'task-6'
-      expect(page.text).to match %r{#{@task2.title}.*#{@task1.title}}
+      expect(page.text.index(@task2.title)).to be< page.text.index(@task1.title)
     end
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :system do
+  before do
+    @task1 = FactoryBot.create :task
+    @task2 = FactoryBot.create :task
+  end
+  describe 'タスク一覧画面を表示した時' do
+    it '作成日の降順でタスクがならんでいること' do
+      visit tasks_path
+      # expect(page.text).to match 'task-6'
+      expect(page.text).to match %r{#{@task2.title}.*#{@task1.title}}
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%82%88%E3%81%86

### 目的
- タスク一覧を作成日で降順（新しく登録したタスクが上）に並び替える

### 達成基準
- タスク一覧画面で作施日順に降順で並んでいる
- 新たにタスクを追加すると、それが一番上に表示される
- 並び順のsystemeテストが実装されている

### 実装
- taskモデルにdefault_scopeを追加して並び順を変えた

### レビューして欲しい点
- systemテストが通りません。。。　正規表現でマッチするように試みてみたのですが、正規表現は正しいにもかかわらずテストは失敗します。どこが間違っていそうでしょうか？
- あるいは並び順をテストする場合は他にイケてる実装がありますか？
